### PR TITLE
Fix app info absence

### DIFF
--- a/src/app/hybrid.js
+++ b/src/app/hybrid.js
@@ -13,20 +13,22 @@ class Hybrid {
     // Hook this on window so it can be required in multiple packs
     window._hybridEventSubscriptions = window._hybridEventSubscriptions || {}
 
-    this.appInfo = this.detectApp(window.appVersion || navigator.userAgent)
-
     this._cachedRadioTokenOnLoad = undefined
     this.on('appLoad', (context) => {
       this._cachedRadioTokenOnLoad = context?.radioToken ?? null
     })
   }
 
+  appInfo() {
+    return this.detectApp(window.appVersion || navigator.userAgent)
+  }
+
   isNativeApp() {
-    return this.appInfo.platform !== 'browser'
+    return this.appInfo().platform !== 'browser'
   }
 
   isVersion({ android, ios }) {
-    const { platform, buildName, buildVersion } = this.appInfo
+    const { platform, buildName, buildVersion } = this.appInfo()
 
     return (
       (platform === 'Android' && android[buildName] && android[buildName] <= parseInt(buildVersion, 10)) ||


### PR DESCRIPTION
When `hybrid` is imported, the constructor is executed immediately during the page load. However, at least on Android, `window.appVersion` is not available at that point. That breaks applications using the `isNativeApp()` check (which we use to determine which [authentication method](https://github.com/dpgradio/vite-vue-starter/blob/13fc356cccf6c74d9f9aa448d68d941eaf572900/src/stores/user.js#L42) to present, for instance).

This PR converts `appInfo` to a method. There are no real cons except for backwards compatibility with applications using `appInfo` directly (I don't think there are any, not the ones using this package at least) and a very very minor performance penalty which I'm not worried about.