### PR TITLE
use OnDPGConsentString callback

### DIFF
--- a/src/privacy/privacy.js
+++ b/src/privacy/privacy.js
@@ -52,9 +52,9 @@ class Privacy {
       this.consentSubscribers.forEach((subscriber) => subscriber(null))
     }, timeoutTime)
 
-    this.pushFunctional(() => {
+    this.pushOnDpgConsentString((dpgConsentString) => {
       clearTimeout(timeout)
-      this.consent = new Consent(window._privacy.consentString, window._privacy.purposesProvider.enabledPurposes)
+      this.consent = new Consent(dpgConsentString)
       this.consentSubscribers.forEach((subscriber) => subscriber(this.consent))
     })
   }
@@ -82,21 +82,19 @@ class Privacy {
     window._privacy.push([type, callback])
   }
 
-  pushFunctional(callback) {
-    this.push('functional', callback)
+  pushOnDpgConsentString(callback) {
+    this.push('onDpgConsentString', callback)
   }
 }
 
-const targetedAdvertisingPurposes = [3, 4]
-
 class Consent {
-  constructor(consentString, purposes) {
+  constructor(consentString) {
     this.consentString = consentString
-    this.purposes = purposes
+    this.purposes = new Set(consentString.split('|'))
   }
 
   allowsTargetedAdvertising() {
-    return targetedAdvertisingPurposes.every((purpose) => this.purposes.has(purpose.toString()))
+    return this.purposes.has('targeted_advertising')
   }
 }
 


### PR DESCRIPTION
tot nu toe gebruikte we consentString en purposesProvider, turns out dat we deze eig niet mogen gebruiken,
en in plaats daarvan zouden de push on consent string moeten gebruiken. 

Om te zorgen dat we geen grote changes moeten doen aan al onze applicaties, gaan we de consent string die zij doorsturen (een string die ge-concat is met "|") opslitsen en in een Set steken zodat de methodes nog altijd het zelfde terug geven.

1 belangerijk detail: purposes 1-10 kunnen we niet meer gebruiken, deze zijn vervangen door woorden
zo is 1: "functional" geworden, deze moeten dus wel nog aangepast worden => turns out it's a lie