### PR TITLE
Create native event listeners ahead of time

### DIFF
--- a/src/app/hybrid.js
+++ b/src/app/hybrid.js
@@ -24,6 +24,19 @@ class Hybrid {
     // Hook this on window so it can be required in multiple packs
     window._hybridEventSubscriptions = window._hybridEventSubscriptions || {}
 
+    // Ensure these native events don't error out because nothing is listening
+    for (const event of [
+      'appLoad',
+      'audioStateChanged',
+      'authenticated',
+      'didAppear',
+      'didHide',
+      'didPrompt',
+      'didAlert',
+    ]) {
+      this.ensureTriggerExists(event)
+    }
+
     this._cachedRadioTokenOnLoad = undefined
     this.on('appLoad', (context) => {
       this._cachedRadioTokenOnLoad = context?.radioToken ?? null


### PR DESCRIPTION
This might be a reason of some Android crashes
