### PR TITLE
Use self-hosted Willy fonts and import all fonts uniformly

### DIFF
--- a/styles/fonts/joe.css
+++ b/styles/fonts/joe.css
@@ -1,34 +1,39 @@
 @font-face {
-	font-family: geomanist;
-	src: url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-light-webfont.eot), url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-light-webfont.woff), url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-light-webfont.woff2);
-	font-weight: 200;
-	font-style: normal
+  font-family: 'geomanist';
+  src: url('https://static.radio.dpgmedia.net/fonts/joe/geomanist/geomanist-light.woff2') format('woff2');
+  font-weight: 200;
+  font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
-	font-family: geomanist;
-	src: url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-book-webfont.eot), url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-book-webfont.woff), url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-book-webfont.woff2);
-	font-weight: 300;
-	font-style: normal
+  font-family: 'geomanist';
+  src: url('https://static.radio.dpgmedia.net/fonts/joe/geomanist/geomanist-book.woff2') format('woff2');
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
-	font-family: geomanist;
-	src: url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-regular-webfont.eot), url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-regular-webfont.woff), url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-regular-webfont.woff2);
-	font-weight: 400;
-	font-style: normal
+  font-family: 'geomanist';
+  src: url('https://static.radio.dpgmedia.net/fonts/joe/geomanist/geomanist-regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
-	font-family: geomanist;
-	src: url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-medium-webfont.eot), url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-medium-webfont.woff), url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-medium-webfont.woff2);
-	font-weight: 500;
-	font-style: normal
+  font-family: 'geomanist';
+  src: url('https://static.radio.dpgmedia.net/fonts/joe/geomanist/geomanist-medium.woff2') format('woff2');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
-	font-family: geomanist;
-	src: url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-bold-webfont.eot), url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-bold-webfont.woff), url(https://static1.qmusic.medialaancdn.be/store/static/fonts/geomanist-bold-webfont.woff2);
-	font-weight: 600;
-	font-style: normal
+  font-family: 'geomanist';
+  src: url('https://static.radio.dpgmedia.net/fonts/joe/geomanist/geomanist-bold.woff2') format('woff2');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
 }

--- a/styles/fonts/qmusic.css
+++ b/styles/fonts/qmusic.css
@@ -1,51 +1,55 @@
 @font-face {
-	font-family: Cervo;
-	src: url(https://fonts.qmusic.be/cervo-light-webfont.ttf), url(https://fonts.qmusic.be/cervo-light-webfont.eot), url(https://fonts.qmusic.be/cervo-light-webfont.woff), url(https://fonts.qmusic.be/cervo-light-webfont.woff2), url(https://fonts.qmusic.be/cervo-light-webfont.svg);
-	font-weight: 400;
-	font-style: normal
+  font-family: 'Cervo';
+  src: url('https://static.radio.dpgmedia.net/fonts/qmusic/cervo/cervo-light.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
-	font-family: Cervo;
-	src: url(https://fonts.qmusic.be/cervo-medium-webfont.ttf), url(https://fonts.qmusic.be/cervo-medium-webfont.eot), url(https://fonts.qmusic.be/cervo-medium-webfont.woff), url(https://fonts.qmusic.be/cervo-medium-webfont.woff2), url(https://fonts.qmusic.be/cervo-medium-webfont.svg);
-	font-weight: 600;
-	font-style: normal
+  font-family: 'Cervo';
+  src: url('https://static.radio.dpgmedia.net/fonts/qmusic/cervo/cervo-medium.woff2') format('woff2');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
-	font-family: Qarla;
-	src: url(https://fonts.qmusic.be/qarla-bold-webfont.ttf), url(https://fonts.qmusic.be/qarla-bold-webfont.eot), url(https://fonts.qmusic.be/qarla-bold-webfont.woff), url(https://fonts.qmusic.be/qarla-bold-webfont.woff2), url(https://fonts.qmusic.be/qarla-bold-webfont.svg);
-	font-weight: 700;
-	font-style: normal
+  font-family: 'Qarla';
+  src: url('https://static.radio.dpgmedia.net/fonts/qmusic/qarla/qarla-bold.woff2') format('woff2');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
-	font-family: Qarla;
-	src: url(https://fonts.qmusic.be/qarla-bolditalic-webfont.ttf), url(https://fonts.qmusic.be/qarla-bolditalic-webfont.eot), url(https://fonts.qmusic.be/qarla-bolditalic-webfont.woff), url(https://fonts.qmusic.be/qarla-bolditalic-webfont.woff2), url(https://fonts.qmusic.be/qarla-bolditalic-webfont.svg);
-	font-weight: 700;
-	font-style: italic
+  font-family: 'Qarla';
+  src: url('https://static.radio.dpgmedia.net/fonts/qmusic/qarla/qarla-bolditalic.woff2') format('woff2');
+  font-weight: 700;
+  font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
-	font-family: Qarla;
-	src: url(https://fonts.qmusic.be/qarla-italic-webfont.ttf), url(https://fonts.qmusic.be/qarla-italic-webfont.eot), url(https://fonts.qmusic.be/qarla-italic-webfont.woff), url(https://fonts.qmusic.be/qarla-italic-webfont.woff2), url(https://fonts.qmusic.be/qarla-italic-webfont.svg);
-	font-weight: 400;
-	font-style: italic
+  font-family: 'Qarla';
+  src: url('https://static.radio.dpgmedia.net/fonts/qmusic/qarla/qarla-italic.woff2') format('woff2');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
 }
 
 @font-face {
-	font-family: Qarla;
-	src: url(https://fonts.qmusic.be/qarla-regular-webfont.ttf), url(https://fonts.qmusic.be/qarla-regular-webfont.eot), url(https://fonts.qmusic.be/qarla-regular-webfont.woff), url(https://fonts.qmusic.be/qarla-regular-webfont.woff2), url(https://fonts.qmusic.be/qarla-regular-webfont.svg);
-	font-weight: 400;
-	font-style: normal
+  font-family: 'Qarla';
+  src: url('https://static.radio.dpgmedia.net/fonts/qmusic/qarla/qarla-regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
 }
 
 @font-face {
-	font-family: BlackBones;
-	src: url(https://fonts.qmusic.be/black-bones.ttf), url(https://fonts.qmusic.be/black-bones.eot), url(https://fonts.qmusic.be/black-bones.woff), url(https://fonts.qmusic.be/black-bones.woff2), url(https://fonts.qmusic.be/black-bones.svg);
-   	font-weight: normal;
-	font-style: normal;
-	font-display: fallback;
+  font-family: 'BlackBones';
+  src: url('https://static.radio.dpgmedia.net/fonts/qmusic/black-bones/black-bones.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
 }
-
-

--- a/styles/fonts/willy.css
+++ b/styles/fonts/willy.css
@@ -1,2 +1,79 @@
-@import url("https://fonts.googleapis.com/css2?family=Anton&family=Mulish:ital,wght@0,400;0,700;1,400;1,700&display=swap");
-@import url("https://use.typekit.net/ijq2qjl.css");
+@font-face {
+  font-family: 'Anton';
+  src: url('https://static.radio.dpgmedia.net/fonts/willy/anton/anton-regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Mulish';
+  src: url('https://static.radio.dpgmedia.net/fonts/willy/mulish/mulish-variable.woff2') format('woff2');
+  font-weight: 400 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Mulish';
+  src: url('https://static.radio.dpgmedia.net/fonts/willy/mulish/mulish-italic-variable.woff2') format('woff2');
+  font-weight: 400 700;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Rift';
+  src: url('https://static.radio.dpgmedia.net/fonts/willy/rift/rift-light.woff2') format('woff2');
+  font-weight: 300;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Rift';
+  src: url('https://static.radio.dpgmedia.net/fonts/willy/rift/rift-regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Rift';
+  src: url('https://static.radio.dpgmedia.net/fonts/willy/rift/rift-italic.woff2') format('woff2');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Rift';
+  src: url('https://static.radio.dpgmedia.net/fonts/willy/rift/rift-medium.woff2') format('woff2');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Rift';
+  src: url('https://static.radio.dpgmedia.net/fonts/willy/rift/rift-demi.woff2') format('woff2');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Rift';
+  src: url('https://static.radio.dpgmedia.net/fonts/willy/rift/rift-bold.woff2') format('woff2');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Rift';
+  src: url('https://static.radio.dpgmedia.net/fonts/willy/rift/rift-bolditalic.woff2') format('woff2');
+  font-weight: 700;
+  font-style: italic;
+  font-display: swap;
+}


### PR DESCRIPTION
This PR migrates all font usage to our "static" cdn. It also standardizes the @font-face declarations.

Moreover, the Willy fonts are now self-hosted.

Finally, we only use `woff2` and do not support any legacy formats anymore.